### PR TITLE
Improve project docs and env setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Example environment configuration
+NEXTAUTH_SECRET=changeme
+NEXTAUTH_URL=http://localhost:3000
+SECRET_KEY=your_aes_secret_key
+MYSQL_HOST=localhost
+MYSQL_USER=root
+MYSQL_PASSWORD=your_mysql_password
+MYSQL_DATABASE=WSOL
+# Base URL used by the client to communicate with the API
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# Next.js Admin Dashboard
+
+This project is a simple Next.js application that demonstrates building an admin dashboard using Ant Design components.
+
+## Getting started
+
+1. **Install dependencies**
+
+   ```bash
+   npm install
+   ```
+
+2. **Configure environment variables**
+
+   Copy `.env.example` to `.env.local` and adjust the values as needed:
+
+   ```bash
+   cp .env.example .env.local
+   ```
+
+   The most important variables are:
+
+   - `NEXTAUTH_SECRET` – secret used by NextAuth.
+   - `SECRET_KEY` – key used to encrypt API requests.
+   - `MYSQL_HOST`, `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_DATABASE` – database connection settings.
+   - `NEXT_PUBLIC_API_BASE_URL` – base URL for API calls from the client.
+
+3. **Run the development server**
+
+   ```bash
+   npm run dev
+   ```
+
+   Visit `http://localhost:3000` in your browser.
+
+## Project structure
+
+- `app` – Next.js pages and API routes.
+- `components` – React components used across the application.
+- `lib` – Utility libraries and database helpers.
+- `Layouts` – Layout components for different page groups.
+- `store/context` – React context providers such as `DrawerContext` and `ThemeContext`.
+- `theme` – Ant Design theme configuration.
+
+## Scripts
+
+- `npm run dev` – start the development server.
+- `npm run build` – build for production.
+- `npm start` – start the production server.
+- `npm run lint` – run ESLint on the project.
+
+## License
+
+This project is provided as‑is for demonstration purposes.

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,7 +1,9 @@
 import axios from "axios";
 import {encrypt} from "@/lib/utils";
 
-const API_BASE_URL = "http://localhost:3000";
+// Base URL for all API requests. This can be overridden via environment
+// variable so that the front‑end can communicate with any back‑end host.
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3000";
 const api = axios.create({
     baseURL: "/api",
     headers: {


### PR DESCRIPTION
## Summary
- allow customizing API base URL via `NEXT_PUBLIC_API_BASE_URL`
- document setup and directory layout
- provide example environment variables

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c0fc7920832a9d56516dd1c3e357