### PR TITLE
Fix form builder bug and migrate to Antd 5

### DIFF
--- a/Layouts/AuthLayout.js
+++ b/Layouts/AuthLayout.js
@@ -1,6 +1,6 @@
 'use client';
 import { SessionProvider } from 'next-auth/react';
-import {ConfigProvider} from 'antd';
+import {ConfigProvider, App} from 'antd';
 import { AntdRegistry } from '@ant-design/nextjs-registry';
 import React from "react";
 import { WSOLTheme, darkTheme } from "../theme/theme";
@@ -11,7 +11,9 @@ export default function LoginLayout({ children }) {
         <ConfigProvider theme={theme === "light" ? WSOLTheme : darkTheme}>
             <AntdRegistry>
                 <SessionProvider>
-                    {children}
+                    <App>
+                        {children}
+                    </App>
                 </SessionProvider>
             </AntdRegistry>
         </ConfigProvider>

--- a/Layouts/MainLayout.js
+++ b/Layouts/MainLayout.js
@@ -1,7 +1,7 @@
 'use client';
 import '@/app/i18n';
 import { SessionProvider } from 'next-auth/react';
-import { ConfigProvider, Layout } from 'antd';
+import { ConfigProvider, Layout, App } from 'antd';
 import { AntdRegistry } from '@ant-design/nextjs-registry';
 import React, { useState } from "react";
 import { WSOLTheme, darkTheme } from "@/theme/theme";
@@ -18,6 +18,7 @@ export default function MainLayout({ children }) {
         <ConfigProvider theme={theme === "light" ? WSOLTheme : darkTheme}>
             <AntdRegistry>
                 <SessionProvider>
+                    <App>
                     <Layout style={{ minHeight: '100vh' }}>
                         <DrawerProvider>
                             <SidebarComponent collapsed={collapsed} setCollapsed={setCollapsed} />
@@ -30,6 +31,7 @@ export default function MainLayout({ children }) {
                             <MainDrawer />
                         </DrawerProvider>
                     </Layout>
+                    </App>
                 </SessionProvider>
             </AntdRegistry>
         </ConfigProvider>

--- a/app/(admin)/autoform/[...form]/page.js
+++ b/app/(admin)/autoform/[...form]/page.js
@@ -1,6 +1,6 @@
 'use client';
 import React, {useEffect, useState, useCallback} from 'react';
-import {Card, message, Typography} from 'antd';
+import {Card, Typography, App} from 'antd';
 import CrudTable from '@/components/CrudTable';
 import {useTitleContext} from "@/components/TitleContext";
 import {DatabaseOutlined} from "@ant-design/icons";
@@ -20,6 +20,7 @@ export default function AutoFormPage() {
     const [dataLoading, setDataLoading] = useState(false);
     const [error, setError] = useState(null);
     const [actualTableNameForApi, setActualTableNameForApi] = useState(null);
+    const { message } = App.useApp();
 
     const fetchData = useCallback(async (tableNameForApi) => {
         if (!tableNameForApi) {

--- a/components/CrudTable.js
+++ b/components/CrudTable.js
@@ -2,9 +2,9 @@
 import React, { useState, useEffect, useMemo } from 'react'; // Added useMemo
 import {
     Table, Button, Space, Modal, Form, Input,
-    Select, DatePicker, Checkbox, message, Card,
+    Select, DatePicker, Checkbox, Card,
     Row, Col, Tooltip, Dropdown, Typography, // Removed Tag
-    Popconfirm, Radio
+    Popconfirm, Radio, App
 } from 'antd';
 import {
     PlusOutlined, DeleteOutlined,
@@ -34,6 +34,7 @@ const CrudTable = ({
     const [modalMode, setModalMode] = useState('add'); // 'add' or 'edit'
     const [editingKey, setEditingKey] = useState(null);
     const [form] = Form.useForm();
+    const { message } = App.useApp();
     const [filterValues, setFilterValues] = useState({});
     const [filteredData, setFilteredData] = useState(data);
     const [searchText, setSearchText] = useState('');


### PR DESCRIPTION
## Summary
- move blank form template to be default to avoid flicker
- migrate remaining components to Ant Design 5 `App` API
- reorder settings tabs and allow setting card group directly in table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854d470ac80832abf95e20e18c9b2e0