### PR TITLE
Fix initial form design save

### DIFF
--- a/components/FormBuilder.js
+++ b/components/FormBuilder.js
@@ -1410,7 +1410,7 @@ const [currentSettingsTab, setCurrentSettingsTab] = useState('general'); // Move
 
         try {
             let response;
-            if (!isNaN(Number(selectedTemplate))) {
+            if (selectedTemplate && !isNaN(Number(selectedTemplate))) {
                 response = await api.put('form-designs', {
                     body: formDesignPayload,
                     where: { id: Number(selectedTemplate) }


### PR DESCRIPTION
## Summary
- save new form designs with POST when no template selected

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6854e4e860bc832aadfb9664d29fb30c