### PR TITLE
Add create-table API and button

### DIFF
--- a/app/api/create-table/route.js
+++ b/app/api/create-table/route.js
@@ -1,0 +1,17 @@
+import { createTable } from "@/lib/mysqldb";
+import { checkPayload } from "@/lib/utils";
+
+export const POST = async (req) => {
+    try {
+        const { tableName, schema } = await checkPayload('post', req);
+        if (!tableName || !schema) {
+            return new Response(JSON.stringify({ success: false, message: 'Missing tableName or schema' }), { status: 400 });
+        }
+        const result = await createTable(tableName, schema);
+        const statusCode = result.status ? 200 : 400;
+        return new Response(JSON.stringify({ success: result.status, message: result.message }), { status: statusCode });
+    } catch (error) {
+        console.error('❌ Error creating table API:', error);
+        return new Response(JSON.stringify({ success: false, message: 'Internal Server Error' }), { status: 500 });
+    }
+};


### PR DESCRIPTION
## Summary
- expose new `create-table` API that calls `mysqldb.createTable`
- enhance FormBuilder generator with ability to trigger table creation

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68551494dfa4832a9184ab24d5ef7c91