### PR TITLE
Implement drop-and-create table update

### DIFF
--- a/app/api/create-table/route.js
+++ b/app/api/create-table/route.js
@@ -1,4 +1,4 @@
-import { createTable, alterTable } from "@/lib/mysqldb";
+import { createTable, dropTable } from "@/lib/mysqldb";
 import { checkPayload } from "@/lib/utils";
 
 export const POST = async (req) => {
@@ -7,14 +7,11 @@ export const POST = async (req) => {
         if (!tableName || !schema) {
             return new Response(JSON.stringify({ success: false, message: 'Missing tableName or schema' }), { status: 400 });
         }
-        const createResult = await createTable(tableName, schema);
-        if (!createResult.status) {
-            return new Response(JSON.stringify({ success: false, message: createResult.message }), { status: 400 });
-        }
+        await dropTable(tableName);
 
-        const updateResult = await alterTable(tableName, schema);
-        const statusCode = updateResult.status ? 200 : 400;
-        return new Response(JSON.stringify({ success: updateResult.status, message: updateResult.message }), { status: statusCode });
+        const createResult = await createTable(tableName, schema);
+        const statusCode = createResult.status ? 200 : 400;
+        return new Response(JSON.stringify({ success: createResult.status, message: createResult.message }), { status: statusCode });
     } catch (error) {
         console.error('❌ Error creating table API:', error);
         return new Response(JSON.stringify({ success: false, message: 'Internal Server Error' }), { status: 500 });

--- a/lib/mysqldb.js
+++ b/lib/mysqldb.js
@@ -217,6 +217,17 @@ export const deleteData = async (table, where) => {
     }
 };
 
+export const dropTable = async (tableName) => {
+    try {
+        const sql = `DROP TABLE IF EXISTS \`${tableName}\``;
+        await pool.execute(sql);
+        return { status: true, message: `Table \`${tableName}\` dropped successfully.` };
+    } catch (error) {
+        console.error('❌ Error dropping table:', error.message);
+        return { status: false, message: error.message };
+    }
+};
+
 export const createTable = async (tableName, schema) => {
     try {
         const columns = Object.entries(schema)


### PR DESCRIPTION
## Summary
- support dropping tables in `lib/mysqldb.js`
- change create-table API route to drop table then recreate

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68552209c0c4832a89410d1d6504de13