### PR TITLE
Add drag and drop support to form builder

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -12,3 +12,15 @@ body {
   overflow-x: hidden;
   font-family: "Prompt", sans-serif;
 }
+
+.drag-handle {
+  cursor: move;
+}
+
+.drag-over-row td {
+  background-color: #e6f7ff;
+}
+
+.dragging-row {
+  opacity: 0.5;
+}


### PR DESCRIPTION
## Summary
- allow reordering fields in the form builder using drag and drop
- show a drag handle in the field list table
- style table rows during drag operations

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858b622f6fc832a8532f7b8650a9970