### PR TITLE
Add settings tab for field options

### DIFF
--- a/components/FormBuilder.js
+++ b/components/FormBuilder.js
@@ -1505,7 +1505,223 @@ const FormBuilder = () => {
             message.error(errorMessage);
         }
     };
-    
+
+    const FieldOptionsTab = () => {
+        const optionsConfig = Form.useWatch('optionsConfig', form);
+        const optionsMode = optionsConfig?.mode || 'manual';
+        const selectedTable = optionsConfig?.table;
+
+        const [tables, setTables] = useState([]);
+        const [columns, setColumns] = useState([]);
+
+        useEffect(() => {
+            const fieldType = form.getFieldValue('type');
+            const needsOptions = ['select', 'radio', 'tags', 'checkbox'].includes(fieldType);
+            if (needsOptions && optionsMode === 'table') {
+                api.get('tables').then(res => {
+                    setTables(res?.data || []);
+                }).catch(err => {
+                    console.error("Failed to fetch tables", err);
+                    message.error("Failed to fetch tables.");
+                });
+            }
+        }, [optionsMode, form.getFieldValue('type')]);
+
+        useEffect(() => {
+            const fieldType = form.getFieldValue('type');
+            const needsOptions = ['select', 'radio', 'tags', 'checkbox'].includes(fieldType);
+            if (needsOptions && optionsMode === 'table' && selectedTable) {
+                api.get(`columns`, {table: selectedTable}).then(res => {
+                    setColumns(res?.data || []);
+                }).catch(err => {
+                    console.error(`Failed to fetch columns for ${selectedTable}`, err);
+                    message.error(`Failed to fetch columns for ${selectedTable}.`);
+                });
+            } else {
+                setColumns([]);
+            }
+        }, [optionsMode, selectedTable, form.getFieldValue('type')]);
+
+        const selectedType = form.getFieldValue('type');
+        const showOptions = ['select', 'radio', 'tags', 'checkbox'].includes(selectedType);
+
+        if (!showOptions) {
+            return (
+                <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description={
+                        <span>
+                            Options are only available for Select, Radio, Checkbox, and Tags field types.
+                            <br />
+                            <Button
+                                type="link"
+                                onClick={() => setCurrentFieldFormTab('basic')}
+                            >
+                                Change field type
+                            </Button>
+                        </span>
+                    }
+                />
+            );
+        }
+
+        return (
+            <>
+                <Form.Item label="Options Source">
+                    <Radio.Group
+                        value={optionsMode}
+                        onChange={e => {
+                            const newMode = e.target.value;
+                            const currentConfig = form.getFieldValue('optionsConfig') || {};
+                            form.setFieldsValue({ optionsConfig: { ...currentConfig, mode: newMode, table: undefined, labelField: undefined, valueField: undefined, json: undefined } });
+                            if (newMode === 'manual' && !form.getFieldValue('options')?.length) {
+                                form.setFieldValue('options', [{ label: 'Option 1', value: 'option1' }]);
+                            } else {
+                                form.setFieldValue('options', []);
+                            }
+                        }}
+                    >
+                        <Radio.Button value="manual">Manual</Radio.Button>
+                        <Radio.Button value="table">From Table</Radio.Button>
+                        <Radio.Button value="json">From JSON</Radio.Button>
+                    </Radio.Group>
+                </Form.Item>
+
+                <Form.Item name="optionsConfig" hidden><Input /></Form.Item>
+
+                {optionsMode === 'manual' && (
+                    <Form.List name="options">
+                        {(fields, { add, remove }) => (
+                            <>
+                                <Alert
+                                    message="Manually define options"
+                                    description="Add, edit or remove options that will be available to users."
+                                    type="info"
+                                    showIcon
+                                    style={{ marginBottom: 16 }}
+                                />
+                                {fields.length === 0 ? (
+                                    <Empty
+                                        image={Empty.PRESENTED_IMAGE_SIMPLE}
+                                        description="No options added yet"
+                                        style={{ margin: '20px 0' }}
+                                    >
+                                        <Button
+                                            type="primary"
+                                            onClick={() => add({ label: 'New Option', value: 'newOption' })}
+                                            icon={<PlusOutlined />}
+                                        >
+                                            Add First Option
+                                        </Button>
+                                    </Empty>
+                                ) : (
+                                    <div style={{ maxHeight: '400px', overflow: 'auto', padding: '8px 0' }}>
+                                        {fields.map((field, index) => (
+                                            <Card
+                                                key={field.key}
+                                                size="small"
+                                                style={{ marginBottom: 8 }}
+                                                title={`Option ${index + 1}`}
+                                                extra={<Button icon={<DeleteOutlined />} onClick={() => remove(field.name)} danger type="text" />}
+                                            >
+                                                <Row gutter={16}>
+                                                    <Col span={12}>
+                                                        <Form.Item {...field} name={[field.name, 'label']} rules={[{ required: true, message: 'Missing label' }]} label="Label" tooltip="Text shown to users">
+                                                            <Input placeholder="Display text" />
+                                                        </Form.Item>
+                                                    </Col>
+                                                    <Col span={12}>
+                                                        <Form.Item {...field} name={[field.name, 'value']} rules={[{ required: true, message: 'Missing value' }]} label="Value" tooltip="Value stored in database">
+                                                            <Input placeholder="Stored value" />
+                                                        </Form.Item>
+                                                    </Col>
+                                                </Row>
+                                            </Card>
+                                        ))}
+                                    </div>
+                                )}
+                                <Form.Item style={{ marginTop: 16 }}>
+                                    <Button type="dashed" onClick={() => add({ label: '', value: '' })} icon={<PlusOutlined />} block>Add Option</Button>
+                                </Form.Item>
+                            </>
+                        )}
+                    </Form.List>
+                )}
+
+                {optionsMode === 'table' && (
+                    <>
+                        <Alert
+                            message="Fetch options from a database table"
+                            description="Select a table, then choose which columns to use for the option label and value."
+                            type="info"
+                            showIcon
+                            style={{ marginBottom: 16 }}
+                        />
+                        <Form.Item name={['optionsConfig', 'table']} label="Table" rules={[{ required: true, message: 'Please select a table' }]}>
+                            <Select
+                                showSearch
+                                loading={tables.length === 0}
+                                placeholder="Select a table"
+                                options={(tables || []).map(t => ({ label: t.TABLE_NAME, value: t.TABLE_NAME }))}
+                                onChange={() => {
+                                    const config = form.getFieldValue('optionsConfig');
+                                    form.setFieldsValue({ optionsConfig: { ...config, labelField: undefined, valueField: undefined } });
+                                }}
+                            />
+                        </Form.Item>
+                        <Form.Item noStyle shouldUpdate={(prev, curr) => prev.optionsConfig?.table !== curr.optionsConfig?.table}>
+                            {() => form.getFieldValue(['optionsConfig', 'table']) ? (
+                                <Row gutter={16}>
+                                    <Col span={12}>
+                                        <Form.Item name={['optionsConfig', 'valueField']} label="Value Field" rules={[{ required: true, message: 'Please select a value field' }]}>
+                                            <Select showSearch loading={columns.length === 0 && !!selectedTable} placeholder="Select field for value" options={(columns || []).map(c => ({ label: c.COLUMN_NAME, value: c.COLUMN_NAME }))} />
+                                        </Form.Item>
+                                    </Col>
+                                    <Col span={12}>
+                                        <Form.Item name={['optionsConfig', 'labelField']} label="Label Field" rules={[{ required: true, message: 'Please select a label field' }]}>
+                                            <Select showSearch loading={columns.length === 0 && !!selectedTable} placeholder="Select field for label" options={(columns || []).map(c => ({ label: c.COLUMN_NAME, value: c.COLUMN_NAME }))} />
+                                        </Form.Item>
+                                    </Col>
+                                </Row>
+                            ) : null}
+                        </Form.Item>
+                    </>
+                )}
+
+                {optionsMode === 'json' && (
+                    <>
+                        <Alert
+                            message="Provide options as a JSON array"
+                            description='The format must be an array of objects, with each object having a "label" and "value" key. e.g. [{"label": "Active", "value": "active"}]'
+                            type="info"
+                            showIcon
+                            style={{ marginBottom: 16 }}
+                        />
+                        <Form.Item
+                            name={['optionsConfig', 'json']}
+                            label="JSON Options"
+                            rules={[{
+                                validator: async (_, value) => {
+                                    if (!value) return;
+                                    try {
+                                        const parsed = JSON.parse(value);
+                                        if (!Array.isArray(parsed)) throw new Error('Must be a JSON array.');
+                                        const isValid = parsed.every(item => typeof item === 'object' && item !== null && 'label' in item && 'value' in item);
+                                        if (!isValid) throw new Error('Each item must be an object with "label" and "value" keys.');
+                                    } catch (e) {
+                                        throw new Error(e.message || 'Invalid JSON format.');
+                                    }
+                                }
+                            }]}
+                        >
+                            <TextArea rows={8} placeholder='[{"label": "Test 1", "value": "test1"}, {"label": "Test 2", "value": "test2"}]' />
+                        </Form.Item>
+                    </>
+                )}
+            </>
+        );
+    };
+
     // Field form for add/edit
     const renderFieldForm = () => {
         
@@ -1610,35 +1826,6 @@ const FormBuilder = () => {
                                         {renderFieldTypeSelection()}
                                         {renderFieldPreview()}
                                         
-                                        <Row gutter={16}>
-                                            <Col span={8}>
-                                                <Form.Item
-                                                    name="required"
-                                                    valuePropName="checked"
-                                                    label="Required"
-                                                >
-                                                    <Switch/>
-                                                </Form.Item>
-                                            </Col>
-                                            <Col span={8}>
-                                                <Form.Item
-                                                    name="filterable"
-                                                    valuePropName="checked"
-                                                    label="Filterable"
-                                                >
-                                                    <Switch/>
-                                                </Form.Item>
-                                            </Col>
-                                            <Col span={8}>
-                                                <Form.Item
-                                                    name="sortable"
-                                                    valuePropName="checked"
-                                                    label="Sortable"
-                                                >
-                                                    <Switch/>
-                                                </Form.Item>
-                                            </Col>
-                                        </Row>
                                     </>
                                 )
                             },
@@ -1653,221 +1840,46 @@ const FormBuilder = () => {
                                         }
                                     </span>
                                 ),
-                                children: (() => {
-                                    const optionsConfig = Form.useWatch('optionsConfig', form);
-                                    const optionsMode = optionsConfig?.mode || 'manual';
-                                    const selectedTable = optionsConfig?.table;
-
-                                    const [tables, setTables] = useState([]);
-                                    const [columns, setColumns] = useState([]);
-
-                                    useEffect(() => {
-                                        const fieldType = form.getFieldValue('type');
-                                        const needsOptions = ['select', 'radio', 'tags', 'checkbox'].includes(fieldType);
-                                        if (needsOptions && optionsMode === 'table') {
-                                            api.get('tables').then(res => {
-                                                setTables(res?.data || []);
-                                            }).catch(err => {
-                                                console.error("Failed to fetch tables", err);
-                                                message.error("Failed to fetch tables.");
-                                            });
-                                        }
-                                    }, [optionsMode, form.getFieldValue('type')]);
-
-                                    useEffect(() => {
-                                        const fieldType = form.getFieldValue('type');
-                                        const needsOptions = ['select', 'radio', 'tags', 'checkbox'].includes(fieldType);
-                                        if (needsOptions && optionsMode === 'table' && selectedTable) {
-                                            api.get(`columns`,{table:selectedTable}).then(res => {
-                                                setColumns(res?.data || []);
-                                            }).catch(err => {
-                                                console.error(`Failed to fetch columns for ${selectedTable}`, err);
-                                                message.error(`Failed to fetch columns for ${selectedTable}.`);
-                                            });
-                                        } else {
-                                            setColumns([]);
-                                        }
-                                    }, [optionsMode, selectedTable, form.getFieldValue('type')]);
-
-                                    const selectedType = form.getFieldValue('type');
-                                    const showOptions = ['select', 'radio', 'tags', 'checkbox'].includes(selectedType);
-
-                                    if (!showOptions) {
-                                        return (
-                                            <Empty
-                                                image={Empty.PRESENTED_IMAGE_SIMPLE}
-                                                description={
-                                                    <span>
-                                                        Options are only available for Select, Radio, Checkbox, and Tags field types.
-                                                        <br />
-                                                        <Button
-                                                            type="link"
-                                                            onClick={() => setCurrentFieldFormTab('basic')}
-                                                        >
-                                                            Change field type
-                                                        </Button>
-                                                    </span>
-                                                }
-                                            />
-                                        );
-                                    }
-
-                                    return (
-                                        <>
-                                            <Form.Item label="Options Source">
-                                                <Radio.Group
-                                                    value={optionsMode}
-                                                    onChange={e => {
-                                                        const newMode = e.target.value;
-                                                        const currentConfig = form.getFieldValue('optionsConfig') || {};
-                                                        form.setFieldsValue({ optionsConfig: { ...currentConfig, mode: newMode, table: undefined, labelField: undefined, valueField: undefined, json: undefined } });
-                                                        if (newMode === 'manual' && !form.getFieldValue('options')?.length) {
-                                                            form.setFieldValue('options', [{ label: 'Option 1', value: 'option1' }]);
-                                                        } else {
-                                                            form.setFieldValue('options', []);
-                                                        }
-                                                    }}
-                                                >
-                                                    <Radio.Button value="manual">Manual</Radio.Button>
-                                                    <Radio.Button value="table">From Table</Radio.Button>
-                                                    <Radio.Button value="json">From JSON</Radio.Button>
-                                                </Radio.Group>
+                                children: <FieldOptionsTab />
+                            },
+                            {
+                                key: 'settings',
+                                label: (
+                                    <span>
+                                        <CheckSquareOutlined/> Settings
+                                    </span>
+                                ),
+                                children: (
+                                    <Row gutter={16}>
+                                        <Col span={8}>
+                                            <Form.Item
+                                                name="required"
+                                                valuePropName="checked"
+                                                label="Required"
+                                            >
+                                                <Switch/>
                                             </Form.Item>
-
-                                            <Form.Item name="optionsConfig" hidden><Input /></Form.Item>
-
-                                            {optionsMode === 'manual' && (
-                                                <Form.List name="options">
-                                                    {(fields, { add, remove }) => (
-                                                        <>
-                                                            <Alert
-                                                                message="Manually define options"
-                                                                description="Add, edit or remove options that will be available to users."
-                                                                type="info"
-                                                                showIcon
-                                                                style={{ marginBottom: 16 }}
-                                                            />
-                                                            {fields.length === 0 ? (
-                                                                <Empty
-                                                                    image={Empty.PRESENTED_IMAGE_SIMPLE}
-                                                                    description="No options added yet"
-                                                                    style={{ margin: '20px 0' }}
-                                                                >
-                                                                    <Button
-                                                                        type="primary"
-                                                                        onClick={() => add({ label: 'New Option', value: 'newOption' })}
-                                                                        icon={<PlusOutlined />}
-                                                                    >
-                                                                        Add First Option
-                                                                    </Button>
-                                                                </Empty>
-                                                            ) : (
-                                                                <div style={{ maxHeight: '400px', overflow: 'auto', padding: '8px 0' }}>
-                                                                    {fields.map((field, index) => (
-                                                                        <Card
-                                                                            key={field.key}
-                                                                            size="small"
-                                                                            style={{ marginBottom: 8 }}
-                                                                            title={`Option ${index + 1}`}
-                                                                            extra={<Button icon={<DeleteOutlined />} onClick={() => remove(field.name)} danger type="text" />}
-                                                                        >
-                                                                            <Row gutter={16}>
-                                                                                <Col span={12}>
-                                                                                    <Form.Item {...field} name={[field.name, 'label']} rules={[{ required: true, message: 'Missing label' }]} label="Label" tooltip="Text shown to users">
-                                                                                        <Input placeholder="Display text" />
-                                                                                    </Form.Item>
-                                                                                </Col>
-                                                                                <Col span={12}>
-                                                                                    <Form.Item {...field} name={[field.name, 'value']} rules={[{ required: true, message: 'Missing value' }]} label="Value" tooltip="Value stored in database">
-                                                                                        <Input placeholder="Stored value" />
-                                                                                    </Form.Item>
-                                                                                </Col>
-                                                                            </Row>
-                                                                        </Card>
-                                                                    ))}
-                                                                </div>
-                                                            )}
-                                                            <Form.Item style={{ marginTop: 16 }}>
-                                                                <Button type="dashed" onClick={() => add({ label: '', value: '' })} icon={<PlusOutlined />} block>Add Option</Button>
-                                                            </Form.Item>
-                                                        </>
-                                                    )}
-                                                </Form.List>
-                                            )}
-
-                                            {optionsMode === 'table' && (
-                                                <>
-                                                    <Alert
-                                                        message="Fetch options from a database table"
-                                                        description="Select a table, then choose which columns to use for the option label and value."
-                                                        type="info"
-                                                        showIcon
-                                                        style={{ marginBottom: 16 }}
-                                                    />
-                                                    <Form.Item name={['optionsConfig', 'table']} label="Table" rules={[{ required: true, message: 'Please select a table' }]}>
-                                                        <Select
-                                                            showSearch
-                                                            loading={tables.length === 0}
-                                                            placeholder="Select a table"
-                                                            options={(tables || []).map(t => ({ label: t.TABLE_NAME, value: t.TABLE_NAME }))}
-                                                            onChange={() => {
-                                                                const config = form.getFieldValue('optionsConfig');
-                                                                form.setFieldsValue({ optionsConfig: { ...config, labelField: undefined, valueField: undefined } });
-                                                            }}
-                                                        />
-                                                    </Form.Item>
-                                                    <Form.Item noStyle shouldUpdate={(prev, curr) => prev.optionsConfig?.table !== curr.optionsConfig?.table}>
-                                                        {() => form.getFieldValue(['optionsConfig', 'table']) ? (
-                                                            <Row gutter={16}>
-                                                                <Col span={12}>
-                                                                    <Form.Item name={['optionsConfig', 'valueField']} label="Value Field" rules={[{ required: true, message: 'Please select a value field' }]}>
-                                                                        <Select showSearch loading={columns.length === 0 && !!selectedTable} placeholder="Select field for value" options={(columns || []).map(c => ({ label: c.COLUMN_NAME, value: c.COLUMN_NAME }))} />
-                                                                    </Form.Item>
-                                                                </Col>
-                                                                <Col span={12}>
-                                                                    <Form.Item name={['optionsConfig', 'labelField']} label="Label Field" rules={[{ required: true, message: 'Please select a label field' }]}>
-                                                                        <Select showSearch loading={columns.length === 0 && !!selectedTable} placeholder="Select field for label" options={(columns || []).map(c => ({ label: c.COLUMN_NAME, value: c.COLUMN_NAME }))} />
-                                                                    </Form.Item>
-                                                                </Col>
-                                                            </Row>
-                                                        ) : null}
-                                                    </Form.Item>
-                                                </>
-                                            )}
-
-                                            {optionsMode === 'json' && (
-                                                <>
-                                                    <Alert
-                                                        message="Provide options as a JSON array"
-                                                        description='The format must be an array of objects, with each object having a "label" and "value" key. e.g. [{"label": "Active", "value": "active"}]'
-                                                        type="info"
-                                                        showIcon
-                                                        style={{ marginBottom: 16 }}
-                                                    />
-                                                    <Form.Item
-                                                        name={['optionsConfig', 'json']}
-                                                        label="JSON Options"
-                                                        rules={[{
-                                                            validator: async (_, value) => {
-                                                                if (!value) return;
-                                                                try {
-                                                                    const parsed = JSON.parse(value);
-                                                                    if (!Array.isArray(parsed)) throw new Error('Must be a JSON array.');
-                                                                    const isValid = parsed.every(item => typeof item === 'object' && item !== null && 'label' in item && 'value' in item);
-                                                                    if (!isValid) throw new Error('Each item must be an object with "label" and "value" keys.');
-                                                                } catch (e) {
-                                                                    throw new Error(e.message || 'Invalid JSON format.');
-                                                                }
-                                                            }
-                                                        }]}
-                                                    >
-                                                        <TextArea rows={8} placeholder='[{"label": "Test 1", "value": "test1"}, {"label": "Test 2", "value": "test2"}]' />
-                                                    </Form.Item>
-                                                </>
-                                            )}
-                                        </>
-                                    );
-                                })()
+                                        </Col>
+                                        <Col span={8}>
+                                            <Form.Item
+                                                name="filterable"
+                                                valuePropName="checked"
+                                                label="Filterable"
+                                            >
+                                                <Switch/>
+                                            </Form.Item>
+                                        </Col>
+                                        <Col span={8}>
+                                            <Form.Item
+                                                name="sortable"
+                                                valuePropName="checked"
+                                                label="Sortable"
+                                            >
+                                                <Switch/>
+                                            </Form.Item>
+                                        </Col>
+                                    </Row>
+                                )
                             }
                         ]}
                     />


### PR DESCRIPTION
## Summary
- reorganize FormBuilder to include a new **Settings** tab
- move Required/Filterable/Sortable controls into this new tab
- refactor Options tab into its own component to satisfy React Hook rules

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68623cee1a18832a8e4a258d883ead0e